### PR TITLE
replace getDeclaredClasses and getDeclaredMethods

### DIFF
--- a/magnolia-templatebuilder/src/main/java/com/merkle/oss/magnolia/templatebuilder/TemplateDefinitionProvider.java
+++ b/magnolia-templatebuilder/src/main/java/com/merkle/oss/magnolia/templatebuilder/TemplateDefinitionProvider.java
@@ -194,13 +194,13 @@ public class TemplateDefinitionProvider extends AbstractDynamicDefinitionProvide
 
     private Stream<Class<?>> streamClasses(final Class<?> clazz, final Class<? extends Annotation> annotationClass) {
         return Arrays
-                .stream(clazz.getDeclaredClasses())
+                .stream(clazz.getClasses())
                 .filter(method -> method.isAnnotationPresent(annotationClass));
     }
 
     private Stream<Method> streamMethods(final Class<?> clazz, final Class<? extends Annotation> annotationClass) {
         return Arrays
-                .stream(clazz.getDeclaredMethods())
+                .stream(clazz.getMethods())
                 .filter(method -> method.isAnnotationPresent(annotationClass) && !Modifier.isStatic(method.getModifiers()));
     }
 


### PR DESCRIPTION
* getDeclaredClasses and getDeclaredMethods only retrieve classes and methods within the clazz itself (regardless of their access modifiers) - inherited classes or methods are not available through these calls
* getClasses and getMethods returns public member classes, interfaces or methods of a class, including those inherited from its superclasses